### PR TITLE
don't overwrite to_jq_upload if exists

### DIFF
--- a/app/models/concerns/active_admin_multi_upload/uploadable.rb
+++ b/app/models/concerns/active_admin_multi_upload/uploadable.rb
@@ -20,7 +20,7 @@ module ActiveAdminMultiUpload::Uploadable
           }
         end
       eoruby
-      class_eval(code)
+      class_eval(code) unless self.instance_methods.include? :to_jq_upload
     end
   end
 end


### PR DESCRIPTION
this allows to define to_jq_upload in the model and use other image uploaders than carrierwave
